### PR TITLE
mkdocs: default plugins string[] to object[]

### DIFF
--- a/packages/backend-app-api/src/config/ObservableConfigProxy.ts
+++ b/packages/backend-app-api/src/config/ObservableConfigProxy.ts
@@ -125,4 +125,7 @@ export class ObservableConfigProxy implements Config {
   getOptionalStringArray(key: string): string[] | undefined {
     return this.select(false)?.getOptionalStringArray(key);
   }
+  getOptionalObjectArray<T extends JsonValue>(key: string): T[] | undefined {
+    return this.select(false)?.getOptionalObjectArray(key);
+  }
 }

--- a/packages/config-loader/src/sources/ObservableConfigProxy.ts
+++ b/packages/config-loader/src/sources/ObservableConfigProxy.ts
@@ -148,4 +148,7 @@ export class ObservableConfigProxy implements Config {
   getOptionalStringArray(key: string): string[] | undefined {
     return this.select(false)?.getOptionalStringArray(key);
   }
+  getOptionalObjectArray<T extends JsonValue>(key: string): T[] | undefined {
+    return this.select(false)?.getOptionalObjectArray(key);
+  }
 }

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -240,6 +240,21 @@ export class ConfigReader implements Config {
     return configs.map((obj, index) => this.copy(obj, `${key}[${index}]`));
   }
 
+  /** {@inheritdoc Config.getOptionalObjectArray} */
+  getOptionalObjectArray<T extends JsonValue>(key: string): T[] | undefined {
+    return this.readConfigValue(key, values => {
+      if (!Array.isArray(values)) {
+        return { expected: 'object-array' };
+      }
+      for (const [index, value] of values.entries()) {
+        if (!isObject(value)) {
+          return { expected: 'object-array', value, key: `${key}[${index}]` };
+        }
+      }
+      return true;
+    });
+  }
+
   /** {@inheritdoc Config.getNumber} */
   getNumber(key: string): number {
     const value = this.getOptionalNumber(key);

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -147,4 +147,9 @@ export type Config = {
    * Reads a configuration value at the given key, expecting it to be an array of strings.
    */
   getOptionalStringArray(key: string): string[] | undefined;
+
+  /**
+   * Same as `getOptionalObjectArray` for objects, but will throw an error if there's no value for the given key.
+   */
+  getOptionalObjectArray<T extends JsonValue>(key: string): T[] | undefined;
 };

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { JsonValue } from '@backstage/types';
 import { ContainerRunner } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import { Writable } from 'stream';
@@ -41,7 +42,7 @@ export type GeneratorConfig = {
   pullImage?: boolean;
   omitTechdocsCoreMkdocsPlugin?: boolean;
   legacyCopyReadmeMdToIndexMd?: boolean;
-  defaultPlugins?: string[];
+  defaultPlugins?: (string | { [key: string]: JsonValue })[]; // Updated type
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I made modifications to the default plugins implementation in the codebase. Previously, we were using a simple array of strings to represent default plugins. However, I have now updated it to use an array of objects instead. Each object contains detailed configuration options for the corresponding plugin. This adjustment makes it more convenient for us to configure plugins and introduces flexibility for adding extra features when needed.

Importantly, I've kept the overall system architecture largely unchanged, ensuring that everything continues to function as it did before. No significant architectural changes have been introduced to maintain a smooth transition and to minimise disruptions. This change simplifies the configuration process while setting the stage for future improvements.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
